### PR TITLE
Fix shell variable assignment parsing and tests for Python 2

### DIFF
--- a/parched.py
+++ b/parched.py
@@ -422,8 +422,16 @@ class PKGBUILD(Package):
             self.release = float(self.release)
 
     def _clean(self, value):
-        """Pythonize a bash string"""
-        return " ".join(shlex.split(value))
+        """Pythonize a bash string.
+
+        shlex strips enclosing double quotes from right-hand side of
+        assignment, but not enclosing single quotes.
+
+        """
+        if value.startswith("'") and value.endswith("'"):
+            return value.strip("'")
+        else:
+            return value
 
     def _clean_array(self, value):
         """Pythonize a bash array"""

--- a/tests.py
+++ b/tests.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2009 Sebastian Nowicki
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -18,27 +21,44 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import unittest
-from datetime import datetime
+from __future__ import unicode_literals
+
 import time
-from StringIO import StringIO # cStringIO.StringIO can't be subclassed
+import unittest
+
+from collections import OrderedDict
+from datetime import datetime
+from io import StringIO
 
 import parched
 
+try:
+    unicode
+except NameError:
+    unicode = None
+
+
 class FileMock(StringIO):
-    def __init__(self, buffer, name=None):
+    def __init__(self, buffer=None, name=None, encoding='utf-8'):
         self._name = name
-        StringIO.__init__(self, buffer)
+        self._encoding = encoding
+        super(FileMock, self).__init__(buffer)
 
     @property
     def name(self):
         return self._name
 
+    def read(self, *args):
+        value = super(FileMock, self).read(*args)
+        if unicode and isinstance(value, unicode):
+            value = value.encode(self._encoding)
+        return value
+
 
 class TarFileMock(object):
     """A mock tarfile object"""
     def __init__(self, *args, **kwargs):
-       self._files = {}
+       self._files = OrderedDict()
 
     def add(self, fileobj):
         self._files[fileobj.name] = fileobj
@@ -137,7 +157,6 @@ class PKGBUILDGenerator(PackageGenerator):
         content.append('pkgver=%s' % self.version)
         content.append('pkgrel=%d' % self.release)
         content.append('pkgdesc="%s"' % self.description)
-        content.append('url=%s' % self.name)
         content.append('arch=(%s)' % " ".join(self.architectures))
         content.append('url=%s' % self.url)
         content.append('license=(%s)' % " ".join(self.licenses))
@@ -193,24 +212,24 @@ class PacmanPackageTest(unittest.TestCase):
         tarfile.add(FileMock("foo", "foo.txt"))
         target = parched.PacmanPackage(tarfileobj=tarfile)
 
-        self.assertEquals(self.package.name, target.name)
-        self.assertEquals(self.package.version, target.version)
-        self.assertEquals(self.package.release, target.release)
-        self.assertEquals(self.package.description, target.description)
-        self.assertEquals(self.package.url, target.url)
-        self.assertEquals(self.package.builddate, target.builddate)
-        self.assertEquals(self.package.size, target.size)
-        self.assertEquals(self.package.packager, target.packager)
-        self.assertEquals(self.package.is_forced, target.is_forced)
-        self.assertEquals(self.package.groups, target.groups)
-        self.assertEquals(self.package.licenses, target.licenses)
-        self.assertEquals(self.package.architectures, target.architectures)
-        self.assertEquals(self.package.replaces, target.replaces)
-        self.assertEquals(self.package.conflicts, target.conflicts)
-        self.assertEquals(self.package.provides, target.provides)
-        self.assertEquals(self.package.backup, target.backup)
-        self.assertEquals(self.package.options, target.options)
-        self.assertEquals(target.files, [".PKGINFO", "foo.txt"])
+        self.assertEqual(self.package.name, target.name)
+        self.assertEqual(self.package.version, target.version)
+        self.assertEqual(self.package.release, target.release)
+        self.assertEqual(self.package.description, target.description)
+        self.assertEqual(self.package.url, target.url)
+        self.assertEqual(self.package.builddate, target.builddate)
+        self.assertEqual(self.package.size, target.size)
+        self.assertEqual(self.package.packager, target.packager)
+        self.assertEqual(self.package.is_forced, target.is_forced)
+        self.assertEqual(self.package.groups, target.groups)
+        self.assertEqual(self.package.licenses, target.licenses)
+        self.assertEqual(self.package.architectures, target.architectures)
+        self.assertEqual(self.package.replaces, target.replaces)
+        self.assertEqual(self.package.conflicts, target.conflicts)
+        self.assertEqual(self.package.provides, target.provides)
+        self.assertEqual(self.package.backup, target.backup)
+        self.assertEqual(self.package.options, target.options)
+        self.assertEqual(target.files, [".PKGINFO", "foo.txt"])
 
 class PKGBUILDTest(unittest.TestCase):
     def setUp(self):
@@ -244,28 +263,28 @@ class PKGBUILDTest(unittest.TestCase):
 
     def test_sane_package(self):
         target = parched.PKGBUILD(fileobj=self.package.as_file())
-        self.assertEquals(self.package.name, target.name)
-        self.assertEquals(self.package.version, target.version)
-        self.assertEquals(self.package.release, target.release)
-        self.assertEquals(self.package.description, target.description)
-        self.assertEquals(self.package.url, target.url)
-        self.assertEquals(self.package.groups, target.groups)
-        self.assertEquals(self.package.licenses, target.licenses)
-        self.assertEquals(self.package.architectures, target.architectures)
-        self.assertEquals(self.package.replaces, target.replaces)
-        self.assertEquals(self.package.conflicts, target.conflicts)
-        self.assertEquals(self.package.provides, target.provides)
-        self.assertEquals(self.package.backup, target.backup)
-        self.assertEquals(self.package.options, target.options)
-        self.assertEquals(self.package.noextract, target.noextract)
-        self.assertEquals(self.package.makedepends, target.makedepends)
-        self.assertEquals(self.package.sources, target.sources)
-        self.assertEquals(self.package.optdepends, target.optdepends)
-        self.assertEquals(self.package.checksums, target.checksums)
-        self.assertEquals(self.package.install, target.install)
+        self.assertEqual(self.package.name, target.name)
+        self.assertEqual(self.package.version, target.version)
+        self.assertEqual(self.package.release, target.release)
+        self.assertEqual(self.package.description, target.description)
+        self.assertEqual(self.package.url, target.url)
+        self.assertEqual(self.package.groups, target.groups)
+        self.assertEqual(self.package.licenses, target.licenses)
+        self.assertEqual(self.package.architectures, target.architectures)
+        self.assertEqual(self.package.replaces, target.replaces)
+        self.assertEqual(self.package.conflicts, target.conflicts)
+        self.assertEqual(self.package.provides, target.provides)
+        self.assertEqual(self.package.backup, target.backup)
+        self.assertEqual(self.package.options, target.options)
+        self.assertEqual(self.package.noextract, target.noextract)
+        self.assertEqual(self.package.makedepends, target.makedepends)
+        self.assertEqual(self.package.sources, target.sources)
+        self.assertEqual(self.package.optdepends, target.optdepends)
+        self.assertEqual(self.package.checksums, target.checksums)
+        self.assertEqual(self.package.install, target.install)
 
     def test_multiline(self):
-        pkgbuild = StringIO()
+        pkgbuild = FileMock()
         pkgbuild.write("""
             source=(foo \\
             baz)
@@ -276,8 +295,8 @@ class PKGBUILDTest(unittest.TestCase):
                 pan)
         """)
         target = parched.PKGBUILD(fileobj=pkgbuild)
-        self.assertEquals(['foo', 'baz'], target.sources)
-        self.assertEquals(['eggs', 'spam', 'pancakes'], target.depends)
+        self.assertEqual(['foo', 'baz'], target.sources)
+        self.assertEqual(['eggs', 'spam', 'pancakes'], target.depends)
 
     def test_substitution(self):
         self.package.sources = [
@@ -290,25 +309,36 @@ class PKGBUILDTest(unittest.TestCase):
             '%s/files/%s-%s.tar.gz' % values,
             '%s/files/%s_doc-%s.tar.gz' % values,
         ]
-        self.assertEquals(parsed_sources, target.sources)
+        self.assertEqual(parsed_sources, target.sources)
 
     def test_non_standard_variable_substitution(self):
-        pkgbuild = StringIO("""
+        pkgbuild = FileMock("""
             _pkgname=Foobar
             sources=($_pkgname.tar.gz)
         """)
         target = parched.PKGBUILD(fileobj=pkgbuild)
-        self.assertEquals(["Foobar.tar.gz"], target.sources)
+        self.assertEqual(["Foobar.tar.gz"], target.sources)
 
     def test_skip_function(self):
-        pkgbuild = StringIO("""
+        pkgbuild = FileMock("""
             pkgname=foo
             build() {
                 pkgname=bar
             }
         """)
         target = parched.PKGBUILD(fileobj=pkgbuild)
-        self.assertEquals("foo", target.name)
+        self.assertEqual("foo", target.name)
+
+    def test_quoted_value(self):
+        """Right-hand side of assignment in quotes is parsed correctly."""
+        self.package.description = "Someone's package"
+        self.package.url = "'http://domain.tld/foo'"
+        target = parched.PKGBUILD(fileobj=self.package.as_file())
+        pkgbuild = self.package.as_file().read()
+        self.assertTrue("pkgdesc=\"Someone's package\"" in pkgbuild)
+        self.assertTrue("url='http://domain.tld/foo'" in pkgbuild)
+        self.assertEqual(self.package.description, "Someone's package")
+        self.assertEqual(self.package.url.strip("'"), target.url)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The following led to an error:

```
pkgdesc="This is some dude's package"
```

(note the single quote inside the double quote-enclosed string)

This PR fixes that and adds a test case for it. See `Pkgbuild._clean()` for more info.

Also fixes running the test under Python 2 and renames deprecated unittest method names.
